### PR TITLE
Increment version to 0.1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='LayerClient',
-    version='0.1.5',
+    version='0.1.6',
     packages=['LayerClient'],
     description='Client for the Layer Platform API',
     url='https://github.com/Jana-Mobile/layer-python',


### PR DESCRIPTION
Increment and release version 0.1.6 of LayerClient.
https://pypi.python.org/pypi/LayerClient/0.1.6
