### PR TITLE
Adds mark receipt delivery

### DIFF
--- a/LayerClient/LayerClient.py
+++ b/LayerClient/LayerClient.py
@@ -18,6 +18,7 @@ LAYER_URI_ANNOUNCEMENTS = 'announcements'
 LAYER_URI_CONVERSATIONS = 'conversations'
 LAYER_URI_MESSAGES = 'messages'
 LAYER_URI_CONTENT = 'content'
+LAYER_URI_RECEIPTS = 'receipts'
 
 
 class LayerPlatformException(Exception):
@@ -319,6 +320,25 @@ class PlatformClient(object):
             )
         )
 
+    def mark_delivery_receipt_message(self, message_uuid='', type='sent'):
+        """
+        Mark delivery receipt for message
+
+        Parameters:
+        - `message_uuid`: The uuid of the message read
+		- `type`: receipt message type
+        """
+        request_data = {
+            'type': type
+        }
+        self._raw_request(
+            METHOD_POST,
+            self._get_layer_uri(
+                LAYER_URI_RECEIPTS,
+                message_uuid
+            ),
+            request_data,
+        )
 
 class Announcement(BaseLayerResponse):
     """
@@ -358,13 +378,15 @@ class Message(BaseLayerResponse):
     """
 
     def __init__(self, id, url, sent_at=None, sender=None,
-                 conversation=None, parts=None, recipient_status=None):
+                 conversation=None, parts=None, recipient_status=None,
+                 is_unread=False):
         super(Message, self).__init__(id, url)
         self.sent_at = sent_at
         self.sender = sender
         self.conversation = conversation
         self.parts = parts
         self.recipient_status = recipient_status
+        self.is_unread = False
 
     @staticmethod
     def from_dict(dict_data):
@@ -379,6 +401,7 @@ class Message(BaseLayerResponse):
                 for part in dict_data.get('parts', [])
             ],
             dict_data.get('recipient_status'),
+            dict_data.get('is_unread'),
         )
 
     def __repr__(self):

--- a/LayerClient/LayerClient.py
+++ b/LayerClient/LayerClient.py
@@ -20,7 +20,6 @@ LAYER_URI_MESSAGES = 'messages'
 LAYER_URI_CONTENT = 'content'
 LAYER_URI_RECEIPTS = 'receipts'
 
-
 class LayerPlatformException(Exception):
 
     def __init__(self, message, http_code=None, code=None, error_id=None):
@@ -320,13 +319,13 @@ class PlatformClient(object):
             )
         )
 
-    def mark_delivery_receipt_message(self, message_uuid='', type='sent'):
+    def mark_delivery_receipt_message(self, message_uuid, type='sent'):
         """
         Mark delivery receipt for message
 
         Parameters:
         - `message_uuid`: The uuid of the message read
-		- `type`: receipt message type
+        - `type`: receipt message type
         """
         request_data = {
             'type': type
@@ -334,8 +333,9 @@ class PlatformClient(object):
         self._raw_request(
             METHOD_POST,
             self._get_layer_uri(
+                LAYER_URI_MESSAGES,
+                message_uuid,
                 LAYER_URI_RECEIPTS,
-                message_uuid
             ),
             request_data,
         )
@@ -379,14 +379,14 @@ class Message(BaseLayerResponse):
 
     def __init__(self, id, url, sent_at=None, sender=None,
                  conversation=None, parts=None, recipient_status=None,
-                 is_unread=False):
+                 is_unread=True):
         super(Message, self).__init__(id, url)
         self.sent_at = sent_at
         self.sender = sender
         self.conversation = conversation
         self.parts = parts
         self.recipient_status = recipient_status
-        self.is_unread = False
+        self.is_unread = is_unread
 
     @staticmethod
     def from_dict(dict_data):

--- a/tests/test_mark_delivery_receipt.py
+++ b/tests/test_mark_delivery_receipt.py
@@ -1,0 +1,29 @@
+from test_utils import MockRequestResponse, TestPlatformClient
+
+
+class TestMarkDeliveryReceipt(TestPlatformClient):
+
+    def test_mark_delivery_receipt(self, layerclient, monkeypatch):
+        def verify_request_args(method, url, headers, data):
+            assert method == "POST"
+            assert url == (
+                "https://api.layer.com/apps/TEST_APP_UUID/"
+                "/messages/TEST_MESSAGE_UUID/receipts"
+			)
+            assert headers == {
+                'Accept': 'application/vnd.layer+json; version=1.0',
+                'Authorization': 'Bearer TEST_BEARER_TOKEN',
+                'Content-Type': 'application/json',
+             }
+            json_data = json.loads(data)
+            assert json_data == {
+                'type': 'read',
+            }
+
+            return MockRequestResponse(True, {})
+
+        monkeypatch.setattr("requests.request", verify_request_args)
+        layerclient.mark_delivery_receipt_message('TEST_MESSAGE_UUID', 'delivery')
+        layerclient.mark_delivery_receipt_message('TEST_MESSAGE_UUID', 'read')
+
+

--- a/tests/test_mark_delivery_receipt.py
+++ b/tests/test_mark_delivery_receipt.py
@@ -8,7 +8,7 @@ class TestMarkDeliveryReceipt(TestPlatformClient):
             assert method == "POST"
             assert url == (
                 "https://api.layer.com/apps/TEST_APP_UUID/"
-                "/messages/TEST_MESSAGE_UUID/receipts"
+                "messages/TEST_MESSAGE_UUID/receipts"
 			)
             assert headers == {
                 'Accept': 'application/vnd.layer+json; version=1.0',
@@ -23,7 +23,6 @@ class TestMarkDeliveryReceipt(TestPlatformClient):
             return MockRequestResponse(True, {})
 
         monkeypatch.setattr("requests.request", verify_request_args)
-        layerclient.mark_delivery_receipt_message('TEST_MESSAGE_UUID', 'delivery')
         layerclient.mark_delivery_receipt_message('TEST_MESSAGE_UUID', 'read')
 
 

--- a/tests/test_mark_delivery_receipt.py
+++ b/tests/test_mark_delivery_receipt.py
@@ -1,3 +1,4 @@
+import json
 from test_utils import MockRequestResponse, TestPlatformClient
 
 


### PR DESCRIPTION
Implements Read and Delivery Receipts in
https://developer.layer.com/docs/client/rest#receipts

I haven't tested this thoroughly yet
I've attached the relevant test

Kindly let me know your thoughts
